### PR TITLE
Used QueryBuilders.queryStringQuery instead of simpleQueryStringQuery…

### DIFF
--- a/service/org/moqui/search/SearchServices.xml
+++ b/service/org/moqui/search/SearchServices.xml
@@ -315,7 +315,7 @@ along with this software (see the LICENSE.md file). If not, see
 
             // get the total search count
             SearchRequestBuilder countSrb = elasticSearchClient.prepareSearch().setIndices(indexName)
-                    .setQuery(QueryBuilders.simpleQueryStringQuery((String) queryString)).setSize(0)
+                    .setQuery(QueryBuilders.queryStringQuery((String) queryString)).setSize(0)
             if (documentType) countSrb.setTypes((String) documentType)
             documentListCount = countSrb.execute().actionGet().getHits().totalHits()
 


### PR DESCRIPTION
… which is consistent with get search hits to get total count