### PR TITLE
Define server_ip as text rather than IP address

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2016 by David E. Jones - jonesde
 Written in 2017 by Shen De Fu  - shendepu
+Written in 2017 by Jens Hardings - jenshp
 
 ===========================================================================
 
@@ -59,4 +60,5 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2016 by David E. Jones - jonesde
 Written in 2017 by Shen De Fu  - shendepu
+Written in 2017 by Jens Hardings - jenshp
 

--- a/src/main/groovy/org/moqui/elasticsearch/ElasticRequestLogFilter.groovy
+++ b/src/main/groovy/org/moqui/elasticsearch/ElasticRequestLogFilter.groovy
@@ -138,7 +138,7 @@ class ElasticRequestLogFilter implements Filter {
         long finalTime = System.currentTimeMillis() - startTime
 
         Map reqMap = ['@timestamp':startTime, remote_ip:clientIpAddress, remote_user:request.getRemoteUser(),
-                server_ip:request.getLocalAddr(), content_type:response.getContentType(),
+                server_ip:request.getLocalAddr()?:request.getServerName(), content_type:response.getContentType(),
                 request_method:request.getMethod(), request_scheme:request.getScheme(), request_host:request.getServerName(),
                 request_path:request.getRequestURI(), request_query:request.getQueryString(), http_version:httpVersion,
                 response:response.getStatus(), time_initial_ms:initialTime, time_final_ms:finalTime, bytes:written,

--- a/src/main/groovy/org/moqui/elasticsearch/ElasticRequestLogFilter.groovy
+++ b/src/main/groovy/org/moqui/elasticsearch/ElasticRequestLogFilter.groovy
@@ -76,7 +76,7 @@ class ElasticRequestLogFilter implements Filter {
 
     final static Map docMapping = [properties:[
             '@timestamp':[type:'date', format:'epoch_millis'], remote_ip:[type:'ip'], remote_user:[type:'keyword'],
-            server_ip:[type:'ip'], content_type:[type:'text'],
+            server_ip:[type:'text'], content_type:[type:'text'],
             request_method:[type:'keyword'], request_scheme:[type:'keyword'], request_host:[type:'keyword'],
             request_path:[type:'text'], request_query:[type:'text'], http_version:[type:'half_float'], response:[type:'short'],
             time_initial_ms:[type:'integer'], time_final_ms:[type:'integer'], bytes:[type:'long'],


### PR DESCRIPTION
This pull request contains a work-around to a limitation when using moqui in a proxied environment (e.g. using an application server behind a web server).
Depending on the implementation, javax.servlet.ServletRequest.getLocalAddr() does not always return a string containing an IP address because that information might not be available to the servlet container. The returned value could be the serverName, a null string or an empty string.
As a result, when elasticsearch tries to parse the string assuming it contains an IP address, it generates an exception. Defining the server_ip field as text rather than IP address avoids this problem.