### PR TITLE
Added parent-join module. elasticsearch 5.5 has break changes that ha…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     compile module('org.codelibs.elasticsearch.module:lang-groovy:5.6.2')
     compile 'org.codelibs.elasticsearch.module:transport-netty4:5.6.2'
     compile 'org.codelibs.elasticsearch.module:reindex:5.6.2'
+    compile 'org.codelibs.elasticsearch.module:parent-join:5.6.2'
 
     // painless script needs antlr4, asm-all (if added put in framework and do modules for pegdown/parboiled so it it shared)
     // problem with lang-painless: 450KB jar file, can't come from jcenter so far, so using groovy in spite of warnings

--- a/home/modules/parent-join/plugin-descriptor.properties
+++ b/home/modules/parent-join/plugin-descriptor.properties
@@ -1,0 +1,44 @@
+# Elasticsearch plugin descriptor file
+# This file must exist as 'plugin-descriptor.properties' in a folder named `elasticsearch`
+# inside all plugins.
+#
+### example plugin for "foo"
+#
+# foo.zip <-- zip file for the plugin, with this structure:
+#|____elasticsearch/
+#| |____   <arbitrary name1>.jar <-- classes, resources, dependencies
+#| |____   <arbitrary nameN>.jar <-- any number of jars
+#| |____   plugin-descriptor.properties <-- example contents below:
+#
+# classname=foo.bar.BazPlugin
+# description=My cool plugin
+# version=2.0
+# elasticsearch.version=2.0
+# java.version=1.7
+#
+### mandatory elements for all plugins:
+#
+# 'description': simple summary of the plugin
+description=This module adds the support parent-child queries and aggregations
+#
+# 'version': plugin's version
+version=5.6.2
+#
+# 'name': the plugin name
+name=parent-join
+#
+# 'classname': the name of the class to load, fully-qualified.
+classname=org.elasticsearch.join.ParentJoinPlugin
+#
+# 'java.version': version of java the code is built against
+# use the system property java.specification.version
+# version string must be a sequence of nonnegative decimal integers
+# separated by "."'s and may have leading zeros
+java.version=1.8
+#
+# 'elasticsearch.version': version of elasticsearch compiled against
+elasticsearch.version=5.6.2
+### optional elements for plugins:
+#
+# 'has.native.controller': whether or not the plugin has a native controller
+has.native.controller=false


### PR DESCRIPTION
…s_child, has_parent and parent_id queries and children aggregation have moved to parent-join module. see https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-5.5.html